### PR TITLE
Style errors appropriately

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,4 +1,16 @@
+$error-color: #FF9494;
+
 .description p {
   border-bottom: 2px solid #2199e8;
   padding-bottom: 1em;
+}
+
+.field_with_errors {
+  label {
+    font-style: italic;
+  }
+
+  textarea, input, select {
+    border: 1px solid $error-color;
+  }
 }

--- a/app/views/delegates/index.html.rb
+++ b/app/views/delegates/index.html.rb
@@ -124,8 +124,16 @@ TEXT
   def error_messages
     return unless flash[:error]
 
-    flash[:error].each do |error|
-      full_row { div(class: 'error') { text(error) } }
+    full_row(class: 'error-container') do
+      div(class: 'callout alert') do
+        h5 "There were errors in your form"
+
+        ul do
+          flash[:error].each do |error|
+            li(error)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #11 

<img width="624" alt="screenshot 2016-03-30 16 57 10" src="https://cloud.githubusercontent.com/assets/59429/14161422/7b2254ce-f698-11e5-828d-4a1f38d5ed33.png">

I didn't put the error messages below the actual form fields, I just styled them red for now.