### PR TITLE
Disable prepared_statements in dev/test

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,7 @@ default: &default
   encoding: unicode
   pool: 5
   timeout: 5000
+  prepared_statements: false
 
 development:
   <<: *default


### PR DESCRIPTION
Postgres + Puma is throwing a bunch of duplicate prepared statement errors on development. This is due to race conditions between the multiple server processes combined with a moronic prepared statements implementation that uses incrementing numbers to name their prepared statements (`a001`, `a002`). How could that ever collide?

@bion This also needs to be configured on Heroku, by adding `?prepared_statements=false` to the end of the `DATABASE_URL`